### PR TITLE
[Feature] implement question and post feature

### DIFF
--- a/src/main/java/like/lion/way/common/controller/CommonController.java
+++ b/src/main/java/like/lion/way/common/controller/CommonController.java
@@ -21,7 +21,7 @@ public class CommonController {
     private final JwtUtil jwtUtil;
 
     @GetMapping("/main")
-    public String mainView(Model model, HttpServletRequest request){
+    public String mainView(Model model){
         model.addAttribute("posts", postService.getAllPosts());
         model.addAttribute("questions", questionService.getAllQuestions());
         return "pages/common/main";

--- a/src/main/java/like/lion/way/feed/controller/ArchieveController.java
+++ b/src/main/java/like/lion/way/feed/controller/ArchieveController.java
@@ -1,0 +1,34 @@
+package like.lion.way.feed.controller;
+
+import java.util.List;
+import like.lion.way.feed.domain.PostBox;
+import like.lion.way.feed.domain.QuestionBox;
+import like.lion.way.feed.service.PostBoxService;
+import like.lion.way.feed.service.QuestionBoxService;
+import like.lion.way.user.domain.User;
+import like.lion.way.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+@RequiredArgsConstructor
+public class ArchieveController {
+    private final PostBoxService postBoxService;
+    private final QuestionBoxService questionBoxService;
+    private final UserService userService;
+    //전체 보관함 (스크랩한 질문과 피드)
+    @GetMapping("/all/archieve/{userId}")
+    public String archieveAll(@PathVariable("userId") Long userId, Model model) {
+        User user= userService.findByUserId(userId);
+        List<PostBox> posts= postBoxService.getPostBoxByUserId(user);
+        model.addAttribute("posts", posts);
+        List<QuestionBox> questions= questionBoxService.getQuestionBoxByUserId(user);
+        model.addAttribute("questions", questions);
+        return "pages/feed/archievePage";
+    }
+
+
+}

--- a/src/main/java/like/lion/way/feed/controller/CommentRestController.java
+++ b/src/main/java/like/lion/way/feed/controller/CommentRestController.java
@@ -9,9 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,20 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class CommentRestController {
     private final PostCommentService postCommentService;
-
+    //댓글 수정
     @PatchMapping("/posts/comments/{commentId}")
     public ResponseEntity<String> updateComment(@PathVariable Long commentId, @RequestBody Map<String, String> payload) {
         try {
             String updatedContent = payload.get("updatedContent");
-            log.info("commentId: {}", commentId);
-            log.info("content: {}", updatedContent);
             postCommentService.updateComment(commentId, updatedContent);
             return ResponseEntity.ok("comment updated successfully.");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to update comment.");
         }
     }
-
+    //댓글 삭제
     @DeleteMapping("/posts/comments/{commentId}")
     public ResponseEntity<String> deleteComment(@PathVariable Long commentId) {
         try {

--- a/src/main/java/like/lion/way/feed/controller/GetUserIp.java
+++ b/src/main/java/like/lion/way/feed/controller/GetUserIp.java
@@ -1,0 +1,25 @@
+package like.lion.way.feed.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class GetUserIp {
+    public static String getRemoteIP(HttpServletRequest request){
+        String ip = request.getHeader("X-FORWARDED-FOR");
+
+        //proxy 환경일 경우
+        if (ip == null || ip.length() == 0) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+
+        //웹로직 서버일 경우
+        if (ip == null || ip.length() == 0) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+
+        if (ip == null || ip.length() == 0) {
+            ip = request.getRemoteAddr() ;
+        }
+
+        return ip;
+    }
+}

--- a/src/main/java/like/lion/way/feed/controller/LikeController.java
+++ b/src/main/java/like/lion/way/feed/controller/LikeController.java
@@ -1,19 +1,13 @@
 package like.lion.way.feed.controller;
 
-import java.util.Collections;
 import like.lion.way.feed.domain.Question;
 import like.lion.way.feed.service.LikeService;
 import like.lion.way.feed.service.QuestionService;
-import like.lion.way.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 @Controller
 @RequiredArgsConstructor
@@ -28,7 +22,7 @@ public class LikeController {
         likeService.likePost(postId, userId);
         return "redirect:/posts/detail/"+postId;
     }
-
+    //질문에 대한 좋아요
     @PostMapping("/questions/like")
     public String likeQuestion(@RequestParam("questionId") Long questionId, @RequestParam("userId") Long userId) {
         likeService.likeQuestion(questionId, userId);

--- a/src/main/java/like/lion/way/feed/controller/Post2Controller.java
+++ b/src/main/java/like/lion/way/feed/controller/Post2Controller.java
@@ -1,0 +1,73 @@
+package like.lion.way.feed.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import like.lion.way.feed.domain.Post;
+import like.lion.way.feed.domain.dto.PostDto;
+import like.lion.way.feed.service.PostBoxService;
+import like.lion.way.feed.service.PostService;
+import like.lion.way.jwt.util.JwtUtil;
+import like.lion.way.user.domain.User;
+import like.lion.way.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class Post2Controller {
+    private final PostService postService;
+    private final JwtUtil jwtUtil;
+    private final UserService userService;
+    private final PostBoxService postBoxService;
+
+    // 로그인한 사용자 정보 조회
+    private User getLoginUser(HttpServletRequest request) {
+        String token = jwtUtil.getCookieValue(request, "accessToken");
+        if (token == null || token.isEmpty()) {
+            return null; // 토큰이 없으면 null 반환
+        }
+        Long loginId = jwtUtil.getUserIdFromToken(token);
+        return userService.findByUserId(loginId);
+    }
+    //고정 핀 설정
+    @PostMapping("/posts/pin/{postId}")
+    public String pinPost(@PathVariable("postId") Long postId) {
+        postService.pinPost(postId);
+        return "redirect:/posts";
+    }
+
+    // 게시판 생성
+    @PostMapping("/posts/create")
+    public String savePost(PostDto postDto, @RequestPart(value = "image") MultipartFile file, HttpServletRequest request){
+        User user = getLoginUser(request);
+        postService.savePost(postDto, file, user);
+        return "redirect:/posts";
+    }
+    // 게시판 생성 페이지로 넘어감
+    @GetMapping("/posts/create")
+    public String createPost() {
+        return "/pages/feed/feedCreate";
+    }
+
+
+    // 게시판 상세 (게시판 == 피드)
+    @GetMapping("/posts/detail/{postId}")
+    public String showDetailPost(@PathVariable("postId") Long postId, Model model, HttpServletRequest request){
+        log.info("postId:::: " + postId);
+        Post post = postService.getPostById(postId);
+        model.addAttribute("post", post);
+
+        model.addAttribute("postBox", postBoxService.getPostBoxByPostId(post).size());
+
+        User loginUser = getLoginUser(request);
+        model.addAttribute("loginUser", loginUser);
+        return "/pages/feed/detailFeed";
+    }
+}

--- a/src/main/java/like/lion/way/feed/controller/PostBoxController.java
+++ b/src/main/java/like/lion/way/feed/controller/PostBoxController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Slf4j
 public class PostBoxController {
     private final PostBoxService postBoxService;
+    //게시글 보관
     @PostMapping("/posts/archieve/{postId}")
     public String archievePost(@PathVariable("postId") Long postId,@RequestParam Long userId){
         log.info("postId: {}", postId);

--- a/src/main/java/like/lion/way/feed/controller/PostCommentController.java
+++ b/src/main/java/like/lion/way/feed/controller/PostCommentController.java
@@ -1,12 +1,7 @@
 package like.lion.way.feed.controller;
 
-import java.time.LocalDateTime;
-import like.lion.way.feed.domain.PostComment;
 import like.lion.way.feed.domain.dto.PostCommentDto;
 import like.lion.way.feed.service.PostCommentService;
-import like.lion.way.feed.service.PostService;
-import like.lion.way.user.domain.User;
-import like.lion.way.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,12 +13,17 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class PostCommentController {
 
     private final PostCommentService postCommentService;
-    private final PostService postService;
-    private final UserService userService;
-
+    //피드의 댓글 저장
     @PostMapping("/posts/comments/{postId}")
     public String saveComments(@PathVariable("postId") Long postId,@RequestParam("userId") Long userId, PostCommentDto postCommentDto) {
         postCommentService.saveComment(postId, postCommentDto, userId);
         return "redirect:/posts/detail/" + postId;
     }
+    //피드의 대댓글 저장
+    @PostMapping("/posts/comments/pre/{postId}")
+    public String savePreComments(@PathVariable Long postId, @RequestParam Long userId, @RequestParam String postCommentContent, @RequestParam(required = false) Long parentCommentPreCommentId){
+        postCommentService.savePreComment(postId, userId, postCommentContent, parentCommentPreCommentId);
+        return "redirect:/posts/detail/" + postId;
+    }
+
 }

--- a/src/main/java/like/lion/way/feed/controller/PostController.java
+++ b/src/main/java/like/lion/way/feed/controller/PostController.java
@@ -1,29 +1,21 @@
 package like.lion.way.feed.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.io.File;
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.Map;
-import like.lion.way.feed.domain.Post;
-import like.lion.way.feed.domain.PostBox;
-import like.lion.way.feed.domain.dto.PostDto;
-import like.lion.way.feed.service.PostBoxService;
+import java.util.List;
 import like.lion.way.feed.service.PostService;
 import like.lion.way.feed.service.QuestionService;
 import like.lion.way.jwt.util.JwtUtil;
+import like.lion.way.user.domain.Follow;
 import like.lion.way.user.domain.User;
+import like.lion.way.user.service.FollowService;
 import like.lion.way.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.multipart.MultipartFile;
+
 
 @Controller
 @RequiredArgsConstructor
@@ -32,107 +24,87 @@ public class PostController {
     private final PostService postService;
     private final UserService userService;
     private final QuestionService questionService;
+    private final FollowService followService;
     private final JwtUtil jwtUtil;
-    private final PostBoxService postBoxService;
-
-    @Value("${image.upload.dir}")
-    private String uploadDir;
 
 
     // 로그인한 사용자 정보 조회
     private User getLoginUser(HttpServletRequest request) {
         String token = jwtUtil.getCookieValue(request, "accessToken");
+        if (token == null || token.isEmpty()) {
+            return null; // 토큰이 없으면 null 반환
+        }
         Long loginId = jwtUtil.getUserIdFromToken(token);
         return userService.findByUserId(loginId);
     }
 
     // 공통된 Model 설정 메서드(새 질문, 답변 완료, 보낸 질문, 거절한 질문)
     private void setCommonModelFilterAttributes(Model model, User user) {
+        if (user == null) {
+            log.error("User object is null");
+            // 필요한 경우, 기본 값 설정 또는 예외 처리
+            model.addAttribute("posts", null);
+            model.addAttribute("rejectedQuestions", 0);
+            model.addAttribute("newQuestions", 0);
+            model.addAttribute("replyQuestions", 0);
+            model.addAttribute("sendQuestions", 0);
+        } else {
+            model.addAttribute("user", user);
+            log.info("user::::" + user.getUsername());
+            model.addAttribute("posts", postService.getPostByUser(user).stream().filter(p -> p.isPostPinStatus() == false).toList());
+            model.addAttribute("pinPosts", postService.getPostByUser(user).stream().filter(p -> p.isPostPinStatus() == true).toList());
 
-        model.addAttribute("user", user);
-        model.addAttribute("posts", postService.getPostByUser(user));
-        model.addAttribute("rejectedQuestions", questionService.getQuestionByAnswerer(user)
-                .stream()
-                .filter(q -> q.getQuestionRejected())
-                .toList().size());
-        model.addAttribute("newQuestions", questionService.getQuestionByAnswerer(user)
-                .stream()
-                .filter(q -> !q.getQuestionRejected() && q.getAnswer() == null)
-                .toList().size());
-        model.addAttribute("replyQuestions", questionService.getQuestionByAnswerer(user)
-                .stream()
-                .filter(q -> !q.getQuestionRejected() && q.getAnswer() != null)
-                .toList().size());
-        model.addAttribute("sendQuestions", questionService.getQuestionByQuestioner(user)
-                .stream()
-                .toList().size());
+            model.addAttribute("rejectedQuestions", questionService.getQuestionByAnswerer(user)
+                    .stream()
+                    .filter(q -> Boolean.TRUE.equals(q.getQuestionRejected()))
+                    .toList().size());
+            model.addAttribute("newQuestions", questionService.getQuestionByAnswerer(user)
+                    .stream()
+                    .filter(q -> Boolean.FALSE.equals(q.getQuestionRejected()) && q.getAnswer() == null)
+                    .toList().size());
+            model.addAttribute("replyQuestions", questionService.getQuestionByAnswerer(user)
+                    .stream()
+                    .filter(q -> Boolean.FALSE.equals(q.getQuestionRejected()) && q.getAnswer() != null)
+                    .toList().size());
+            model.addAttribute("sendQuestions", questionService.getQuestionByQuestioner(user)
+                    .stream()
+                    .toList().size());
+        }
     }
+
 
     // 내 게시판 보여주기
     @GetMapping("/posts")
     public String getPosts(Model model, HttpServletRequest request){
         User user = getLoginUser(request);
+        model.addAttribute("followers", followService.getFollowerList(request).size());
+        model.addAttribute("followings", followService.getFollowingList(request).size());
         setCommonModelFilterAttributes(model, user);
         model.addAttribute("loginUser", user);
         return "/pages/feed/userFeed";
     }
 
     // userId에 해당하는 게시판 보여주기
-    @GetMapping("/posts/{userId}")
-    public String getPostsByUserId(@PathVariable("userId") Long userId, Model model, HttpServletRequest request) {
+    @GetMapping("/posts/{username}")
+    public String getPostsByUserId(@PathVariable("username") String username, Model model, HttpServletRequest request) {
+        log.info("username::::" + username);
         User loginUser = getLoginUser(request);
-        User user = userService.findByUserId(userId);
+        model.addAttribute("followers", followService.getFollowerList(request).size());
+        model.addAttribute("followings", followService.getFollowingList(request).size());
+        if (loginUser == null) {
+            // 로그인 사용자가 없는 경우 처리
+            log.error("Login user not found.");
+            // 필요에 따라 예외를 던지거나 기본 페이지로 리다이렉트
+            return "redirect:/user/login"; // 예를 들어 로그인 페이지로 리다이렉트
+        }
+        User user = userService.findByUsername(username);
+        if (user == null) {
+            log.error("User with username {} not found", username);
+            // 필요에 따라 예외를 던지거나 기본 페이지로 리다이렉트
+            return "redirect:/posts"; // 예를 들어 게시판 목록 페이지로 리다이렉트
+        }
         model.addAttribute("loginUser", loginUser);
         setCommonModelFilterAttributes(model, user);
         return "/pages/feed/userFeed";
-    }
-
-    // 게시판 생성 페이지로 넘어감
-    @GetMapping("/posts/create")
-    public String createPost() {
-        return "/pages/feed/feedCreate";
-    }
-
-    // 게시판 생성
-    @PostMapping("/posts/create")
-    public String savePost(PostDto postDto, @RequestPart(value = "image") MultipartFile file, HttpServletRequest request){
-        Post post = new Post();
-        post.setPostTitle(postDto.getTitle()); // 제목
-        post.setPostContent(postDto.getContent()); // 내용
-
-        // 이미지 파일 저장
-        if (!file.isEmpty()) {
-            try {
-                String fileName = System.currentTimeMillis() + "_" + file.getOriginalFilename();
-                String filePath = uploadDir + File.separator + fileName;
-                File dest = new File(filePath);
-                file.transferTo(dest);
-                post.setPostImageUrl(fileName); // 웹에서 접근할 경로
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
-        User user = getLoginUser(request);
-        log.info("username::::" + user.getUsername());
-        post.setUser(user); // 작성자 설정
-        post.setPostCreatedAt(LocalDateTime.now()); // 작성일
-        post.setPostLike(0); // 좋아요 수
-        postService.savePost(post);
-        return "redirect:/posts";
-    }
-
-    // 게시판 상세 (게시판 == 피드)
-    @GetMapping("/posts/detail/{postId}")
-    public String showDetailPost(@PathVariable("postId") Long postId, Model model, HttpServletRequest request){
-        log.info("postId:::: " + postId);
-        Post post = postService.getPostById(postId);
-        model.addAttribute("post", post);
-
-        model.addAttribute("postBox", postBoxService.getPostBoxByPostId(post).size());
-
-        User loginUser = getLoginUser(request);
-        model.addAttribute("loginUser", loginUser);
-        return "/pages/feed/detailFeed";
     }
 }

--- a/src/main/java/like/lion/way/feed/controller/PostRestController.java
+++ b/src/main/java/like/lion/way/feed/controller/PostRestController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostRestController {
 
     private final PostService postService;
-
+    //게시글 (피드) 수정
     @PatchMapping("/posts/{postId}")
     public ResponseEntity<String> updatePost(@PathVariable("postId") Long postId, @RequestParam String title, @RequestParam String content) {
         try {
@@ -26,7 +25,7 @@ public class PostRestController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to update post.");
         }
     }
-
+    //게시글 삭제
     @DeleteMapping("/posts")
     public ResponseEntity<String> deletePost(@RequestParam Long id) {
         try {

--- a/src/main/java/like/lion/way/feed/controller/Question2Controller.java
+++ b/src/main/java/like/lion/way/feed/controller/Question2Controller.java
@@ -1,0 +1,26 @@
+package like.lion.way.feed.controller;
+
+import like.lion.way.feed.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class Question2Controller {
+    private final QuestionService questionService;
+    //질문 고정
+    @PostMapping("/questions/pin/{questionId}")
+    public String pinQuestion(@PathVariable("questionId") Long questionId) {
+        questionService.pinQuestion(questionId);
+        return "redirect:/questions/create";
+    }
+    //질문 삭제
+    @PostMapping("/questions/delete")
+    public String deleteQuestion(@RequestParam("questionId") Long questionId) {
+        questionService.deleteQuestion(questionId);
+        return "redirect:/questions/create";
+    }
+}

--- a/src/main/java/like/lion/way/feed/controller/QuestionBoxController.java
+++ b/src/main/java/like/lion/way/feed/controller/QuestionBoxController.java
@@ -1,5 +1,8 @@
 package like.lion.way.feed.controller;
 
+import like.lion.way.feed.service.QuestionBoxService;
+import like.lion.way.user.domain.User;
+import like.lion.way.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -10,9 +13,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequiredArgsConstructor
 @Slf4j
 public class QuestionBoxController {
+    private final QuestionBoxService questionBoxService;
+    private final UserService userService;
+    //질문 보관
     @PostMapping("/questions/archieve")
     public String archieveQuestion(@RequestParam("questionId") Long questionId, @RequestParam("userId") Long userId) {
-
-        return null;
+        questionBoxService.archieveQuestion(questionId, userId);
+        User user= userService.findByUserId(userId);
+        String username= user.getUsername();
+        return "redirect:/posts";
     }
 }

--- a/src/main/java/like/lion/way/feed/controller/QuestionFilterController.java
+++ b/src/main/java/like/lion/way/feed/controller/QuestionFilterController.java
@@ -1,6 +1,7 @@
 package like.lion.way.feed.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Comparator;
 import like.lion.way.feed.domain.Question;
 import like.lion.way.feed.service.QuestionService;
 import like.lion.way.jwt.util.JwtUtil;
@@ -51,15 +52,19 @@ public class QuestionFilterController {
         User loginUser = getLoginUser(request);
         setCommonModelAttributes(model, loginUser, request);
         setFilteredQuestions(model, loginUser, Question::getQuestionRejected);
-        return "pages/feed/filterQuestionPage";
+        return "pages/feed/rejectedQuestionPage";
     }
 
-    // 새 질문 리스트
+    // 새 질문 리스트 내림차순 정렬
     @GetMapping("/questions/new/{userId}")
     public String showNewQuestion(@PathVariable("userId") Long userId, Model model, HttpServletRequest request) {
         User user = userService.findByUserId(userId);
         setCommonModelAttributes(model, user, request);
-        setFilteredQuestions(model, user, q -> !q.getQuestionRejected() && q.getAnswer() == null);
+        model.addAttribute("question", questionService.getQuestionByAnswerer(user)
+                .stream()
+                .filter(q -> !q.getQuestionRejected() && q.getAnswer() == null)
+                .sorted(Comparator.comparing(Question::getQuestionDate).reversed())
+                .collect(Collectors.toList()));
         return "pages/feed/filterQuestionPage";
     }
 

--- a/src/main/java/like/lion/way/feed/controller/QuestionRestcontroller.java
+++ b/src/main/java/like/lion/way/feed/controller/QuestionRestcontroller.java
@@ -1,6 +1,5 @@
 package like.lion.way.feed.controller;
 
-import java.util.Map;
 import like.lion.way.feed.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,7 +7,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class QuestionRestcontroller {
     private final QuestionService questionService;
-
+    //답변 수정
     @PatchMapping("/questions/answer/edit/{questionId}")
     public ResponseEntity<String> editAnswer(@PathVariable Long questionId, @RequestParam(name = "answer") String response) {
         try {

--- a/src/main/java/like/lion/way/feed/domain/Question.java
+++ b/src/main/java/like/lion/way/feed/domain/Question.java
@@ -48,10 +48,13 @@ public class Question {
     private Boolean questionStatus;
 
     @Column(name = "question_rejected", columnDefinition = "TINYINT DEFAULT 0")
-    private Boolean questionRejected;
+    private Boolean questionRejected= false;
 
     @Column(name = "question_like", columnDefinition = "INT DEFAULT 0")
     private Integer questionLike = 0;
+
+    @Column(name= "user_ip")
+    private String userIp;
 
     @ManyToOne
     @JoinColumn(name = "questioner_id", referencedColumnName = "user_id")

--- a/src/main/java/like/lion/way/feed/domain/QuestionBox.java
+++ b/src/main/java/like/lion/way/feed/domain/QuestionBox.java
@@ -6,9 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.Set;
 import like.lion.way.user.domain.User;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,8 +20,9 @@ public class QuestionBox {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long questionBoxId;
 
-    @OneToMany(mappedBy = "questionBox")
-    private Set<Question> questions;
+    @ManyToOne
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/like/lion/way/feed/repository/PostBoxRepository.java
+++ b/src/main/java/like/lion/way/feed/repository/PostBoxRepository.java
@@ -13,4 +13,6 @@ public interface PostBoxRepository extends JpaRepository<PostBox, Long> {
     Optional<PostBox> findByUserAndPost(User user, Post post);
 
     List<PostBox> findByPost(Post post);
+
+    List<PostBox> findByUser(User user);
 }

--- a/src/main/java/like/lion/way/feed/repository/PostRepository.java
+++ b/src/main/java/like/lion/way/feed/repository/PostRepository.java
@@ -11,4 +11,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByOrderByPostCreatedAtAsc();
 
     List<Post> findPostByUser(User user);
+
 }

--- a/src/main/java/like/lion/way/feed/repository/QuestionBoxRepository.java
+++ b/src/main/java/like/lion/way/feed/repository/QuestionBoxRepository.java
@@ -1,9 +1,15 @@
 package like.lion.way.feed.repository;
 
+import java.util.List;
+import like.lion.way.feed.domain.Question;
 import like.lion.way.feed.domain.QuestionBox;
+import like.lion.way.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QuestionBoxRepository extends JpaRepository<QuestionBox, Long> {
+    QuestionBox findByUserAndQuestion(User user, Question question);
+
+    List<QuestionBox> findByUser(User user);
 }

--- a/src/main/java/like/lion/way/feed/service/LikeService.java
+++ b/src/main/java/like/lion/way/feed/service/LikeService.java
@@ -1,6 +1,5 @@
 package like.lion.way.feed.service;
 
-import like.lion.way.feed.domain.Like;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/like/lion/way/feed/service/PostBoxService.java
+++ b/src/main/java/like/lion/way/feed/service/PostBoxService.java
@@ -3,6 +3,7 @@ package like.lion.way.feed.service;
 import java.util.List;
 import like.lion.way.feed.domain.Post;
 import like.lion.way.feed.domain.PostBox;
+import like.lion.way.user.domain.User;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,4 +11,6 @@ public interface PostBoxService {
     PostBox archievePost(Long postId, Long userId);
 
     List<PostBox> getPostBoxByPostId(Post post);
+
+    List<PostBox> getPostBoxByUserId(User user);
 }

--- a/src/main/java/like/lion/way/feed/service/PostCommentService.java
+++ b/src/main/java/like/lion/way/feed/service/PostCommentService.java
@@ -11,4 +11,6 @@ public interface PostCommentService {
     PostComment updateComment(Long commentId, String content);
 
     void deleteComment(Long commentId);
+
+    PostComment savePreComment(Long postId, Long userId, String postCommentContent, Long parentCommentPreCommentId);
 }

--- a/src/main/java/like/lion/way/feed/service/PostService.java
+++ b/src/main/java/like/lion/way/feed/service/PostService.java
@@ -2,14 +2,13 @@ package like.lion.way.feed.service;
 
 import java.util.List;
 import like.lion.way.feed.domain.Post;
-import like.lion.way.feed.domain.PostBox;
+import like.lion.way.feed.domain.dto.PostDto;
 import like.lion.way.user.domain.User;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public interface PostService {
-    Post savePost(Post post);
-
     List<Post> getAllPosts();
 
     Post getPostById(Long id);
@@ -20,4 +19,7 @@ public interface PostService {
 
     List<Post> getPostByUser(User user);
 
+    Post pinPost(Long postId);
+
+    Post savePost(PostDto postDto, MultipartFile file, User user);
 }

--- a/src/main/java/like/lion/way/feed/service/QuestionBoxService.java
+++ b/src/main/java/like/lion/way/feed/service/QuestionBoxService.java
@@ -1,7 +1,13 @@
 package like.lion.way.feed.service;
 
+import java.util.List;
+import like.lion.way.feed.domain.QuestionBox;
+import like.lion.way.user.domain.User;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface QuestionBoxService {
+    QuestionBox archieveQuestion(Long questionId, Long userId);
+
+    List<QuestionBox> getQuestionBoxByUserId(User user);
 }

--- a/src/main/java/like/lion/way/feed/service/QuestionService.java
+++ b/src/main/java/like/lion/way/feed/service/QuestionService.java
@@ -1,13 +1,14 @@
 package like.lion.way.feed.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import like.lion.way.feed.domain.Question;
 import like.lion.way.user.domain.User;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public interface QuestionService {
-    Question saveQuestion(Question newQuestion);
 
     List<Question> getAllQuestions();
 
@@ -18,4 +19,14 @@ public interface QuestionService {
     List<Question> getQuestionByAnswerer(User user);
 
     List<Question> getQuestionByQuestioner(User user);
+
+    Question pinQuestion(Long questionId);
+
+    Question rejectedQuestion(Question question);
+
+    void deleteQuestion(Long questionId);
+
+    Question saveQuestion(User user, Long userId, String question, boolean isAnonymous, MultipartFile image, HttpServletRequest request);
+
+    Question saveQuestion(Question question, String answer);
 }

--- a/src/main/java/like/lion/way/feed/service/imp/PostBoxServiceImpl.java
+++ b/src/main/java/like/lion/way/feed/service/imp/PostBoxServiceImpl.java
@@ -46,4 +46,9 @@ public class PostBoxServiceImpl implements PostBoxService {
     public List<PostBox> getPostBoxByPostId(Post post) {
         return postBoxRepository.findByPost(post);
     }
+
+    @Override
+    public List<PostBox> getPostBoxByUserId(User user) {
+        return postBoxRepository.findByUser(user);
+    }
 }

--- a/src/main/java/like/lion/way/feed/service/imp/PostCommentServiceImpl.java
+++ b/src/main/java/like/lion/way/feed/service/imp/PostCommentServiceImpl.java
@@ -31,6 +31,7 @@ public class PostCommentServiceImpl implements PostCommentService {
     }
 
     @Override
+    @Transactional
     public PostComment updateComment(Long commentId, String content) {
         PostComment postComment = postCommentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("Invalid comment ID"));
         postComment.setPostCommentContent(content);
@@ -40,5 +41,18 @@ public class PostCommentServiceImpl implements PostCommentService {
     @Override
     public void deleteComment(Long commentId) {
         postCommentRepository.deleteById(commentId);
+    }
+
+    @Override
+    @Transactional
+    public PostComment savePreComment(Long postId, Long userId, String postCommentContent,
+                                      Long parentCommentPreCommentId) {
+        PostComment postComment = new PostComment();
+        postComment.setPostCommentContent(postCommentContent);
+        postComment.setPostCommentCreatedAt(LocalDateTime.now());
+        postComment.setPost(postService.getPostById(postId));
+        postComment.setUser(userService.findByUserId(userId));
+        postComment.setPostCommentPreCommentId(parentCommentPreCommentId);
+        return postCommentRepository.save(postComment);
     }
 }

--- a/src/main/java/like/lion/way/feed/service/imp/QuestionBoxServiceImpl.java
+++ b/src/main/java/like/lion/way/feed/service/imp/QuestionBoxServiceImpl.java
@@ -1,8 +1,42 @@
 package like.lion.way.feed.service.imp;
 
+import java.util.List;
+import like.lion.way.feed.domain.Question;
+import like.lion.way.feed.domain.QuestionBox;
+import like.lion.way.feed.repository.QuestionBoxRepository;
 import like.lion.way.feed.service.QuestionBoxService;
+import like.lion.way.feed.service.QuestionService;
+import like.lion.way.user.domain.User;
+import like.lion.way.user.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class QuestionBoxServiceImpl implements QuestionBoxService {
+    private final QuestionService questionService;
+    private final UserService userService;
+    private final QuestionBoxRepository questionBoxRepository;
+
+    @Override
+    public QuestionBox archieveQuestion(Long questionId, Long userId) {
+        Question question= questionService.getQuestionById(questionId);
+        User user = userService.findByUserId(userId);
+        QuestionBox existingQuestionBox = questionBoxRepository.findByUserAndQuestion(user, question);
+
+        if(existingQuestionBox != null) {
+            questionBoxRepository.delete(existingQuestionBox);
+            return null;
+        } else {
+            QuestionBox questionBox = new QuestionBox();
+            questionBox.setQuestion(question);
+            questionBox.setUser(user);
+            return questionBoxRepository.save(questionBox);
+        }
+    }
+
+    @Override
+    public List<QuestionBox> getQuestionBoxByUserId(User user) {
+        return questionBoxRepository.findByUser(user);
+    }
 }

--- a/src/main/java/like/lion/way/feed/service/imp/QuestionServiceImpl.java
+++ b/src/main/java/like/lion/way/feed/service/imp/QuestionServiceImpl.java
@@ -1,24 +1,32 @@
 package like.lion.way.feed.service.imp;
 
+import static like.lion.way.feed.controller.GetUserIp.getRemoteIP;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import like.lion.way.feed.domain.Question;
 import like.lion.way.feed.repository.QuestionRepository;
 import like.lion.way.feed.service.QuestionService;
 import like.lion.way.user.domain.User;
+import like.lion.way.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class QuestionServiceImpl implements QuestionService {
 
     private final QuestionRepository questionRepository;
+    private final UserService userService;
 
-    @Override
-    public Question saveQuestion(Question newQuestion) {
-        return questionRepository.save(newQuestion);
-    }
+    @Value("${image.upload.dir}")
+    private String uploadDir;
 
     @Override
     public List<Question> getAllQuestions() {
@@ -48,4 +56,73 @@ public class QuestionServiceImpl implements QuestionService {
         return questionRepository.findQuestionsByQuestioner(user);
     }
 
+    @Override
+    public Question pinQuestion(Long questionId) {
+        Question question = questionRepository.getByQuestionId(questionId);
+        if(question.getQuestionPinStatus() ==true){
+            question.setQuestionPinStatus(false);
+        }else{
+            question.setQuestionPinStatus(true);
+        }
+        return questionRepository.save(question);
+    }
+
+    @Override
+    public Question rejectedQuestion(Question question) {
+        if(question.getQuestionRejected() == true) {
+            question.setQuestionRejected(false);
+        }else{
+            question.setQuestionRejected(true);
+        }
+        return questionRepository.save(question);
+    }
+
+    @Override
+    public void deleteQuestion(Long questionId) {
+        Question question = questionRepository.getByQuestionId(questionId);
+        questionRepository.delete(question);
+    }
+
+    @Override
+    @Transactional
+    public Question saveQuestion(User user, Long userId, String question, boolean isAnonymous, MultipartFile image, HttpServletRequest request) {
+        Question newQuestion = new Question();
+        newQuestion.setQuestion(question);  //질문 저장
+        newQuestion.setQuestionDate(LocalDateTime.now()); //질문 생성일
+        //익명 여부에 따라
+        if(isAnonymous) {
+            newQuestion.setQuestioner(null);
+            newQuestion.setUserIp(getRemoteIP(request));
+
+        } else {
+            newQuestion.setQuestioner(user);
+        }
+        if (!image.isEmpty()) { //이미지
+            try {
+                String fileName = System.currentTimeMillis() + "_" + image.getOriginalFilename();
+                String filePath = uploadDir + File.separator + fileName;
+                File dest = new File(filePath);
+                image.transferTo(dest);
+                newQuestion.setQuestionImageUrl(fileName); // 웹에서 접근할 경로
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        User questionPageUser= userService.findByUserId(userId);
+        newQuestion.setAnswerer(questionPageUser);
+        newQuestion.setQuestionDeleteYN(false);
+        newQuestion.setQuestionStatus(false);
+        newQuestion.setQuestionPinStatus(false);
+        newQuestion.setQuestionRejected(false);
+        return questionRepository.save(newQuestion);
+    }
+
+    @Override
+    @Transactional
+    public Question saveQuestion(Question question, String answer) {
+        question.setAnswer(answer);
+        question.setQuestionStatus(true);
+        question.setAnswerDate(LocalDateTime.now());
+        return questionRepository.save(question);
+    }
 }

--- a/src/main/resources/static/css/common/main.css
+++ b/src/main/resources/static/css/common/main.css
@@ -1,7 +1,55 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    margin-top: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #ffffff; /* 배경색 추가 */
+}
 .feed-item {
     background-color: #FFD6B0;
     padding: 15px;
     border-radius: 10px;
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
     margin-bottom: 10px;
+    display: flex;
+    width: 900px;
+    flex-direction: column;
+}
+
+.btnContainer {
+    display: flex;
+    justify-content: flex-end; /* Align items to the right */
+    align-items: center; /* Center items vertically */
+    margin-top: auto; /* Push the button to the bottom */
+}
+
+.detailBtn {
+    background-color: #ff6746;
+    border: none;
+    color: white;
+    padding: 5px 10px; /* Adjust padding */
+    text-align: center;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 12px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.detailBtn a {
+    color: white;
+    text-decoration: none;
+    display: inline-block;
+    width: auto;
+    height: auto;
+    text-align: center;
+    line-height: normal;
+    font-size: inherit;
+    font-weight: inherit;
+    padding: 0; /* Remove any padding */
+    margin: 0; /* Remove any margin */
 }

--- a/src/main/resources/static/css/feed/detailFeed.css
+++ b/src/main/resources/static/css/feed/detailFeed.css
@@ -124,7 +124,7 @@ body {
     font-size: 14px;
 }
 
-.edit-comment-btn, .delete-comment-btn {
+.edit-comment-btn, .delete-comment-btn , .reply-comment-btn{
     background: none;
     border: none;
     cursor: pointer;
@@ -161,7 +161,7 @@ body {
     align-items: end;
 }
 
-#editPostForm button, .edit-comment-form button {
+#editPostForm button, .edit-comment-form button, .save-comment-btn, .cancel-edit-btn {
     padding: 5px 10px;
     border: none;
     border-radius: 5px;
@@ -177,3 +177,78 @@ body {
     color: #FF6746;
     margin-right: 10px;
 }
+/* 댓글 컨테이너 스타일 */
+.comments-section {
+    margin-top: 20px;
+}
+
+.list-group-item {
+    background-color: #f9f9f9;
+    border: 1px solid #ddd;
+    padding: 15px;
+    margin-bottom: 10px;
+    border-radius: 5px;
+}
+
+/* 댓글 텍스트 스타일 */
+.comment-text {
+    font-size: 16px;
+    margin-bottom: 10px;
+}
+
+/* 답글 컨테이너 스타일 */
+.reply-item {
+    background-color: #f1f1f1;
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin: 10px 0 10px 30px; /* 답글 들여쓰기 */
+    border-radius: 5px;
+}
+
+/* 버튼 스타일 */
+.edit-comment-btn, .delete-comment-btn, .reply-comment-btn {
+    background-color: #FF6746;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    margin-right: 5px;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.edit-comment-btn:hover, .delete-comment-btn:hover, .reply-comment-btn:hover {
+    background-color: #FFD6B0;
+}
+
+.submit-reply-btn, .cancel-reply-btn, .save-comment-btn, .cancel-reply-edit-btn{
+    background-color: #FF6746;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    margin-right: 5px;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.submit-reply-btn:hover, .cancel-reply-btn:hover , .save-comment-btn:hover , cancel-reply-edit-btn:hover{
+    background-color: #FFD6B0;
+}
+
+/* 댓글 폼 스타일 */
+.reply-comment-form {
+    margin-top: 10px;
+}
+
+.reply-comment-form textarea {
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 10px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    resize: none;
+}
+
+.reply-comment-form button {
+    padding: 5px 15px;
+}
+

--- a/src/main/resources/static/css/feed/feed.css
+++ b/src/main/resources/static/css/feed/feed.css
@@ -22,11 +22,11 @@ body {
 }
 
 .profile-picture {
-    width: 50px;
-    height: 50px;
+    width: 100px;
+    height: 100px;
     background-color: #ddd;
     border-radius: 50%;
-    margin-right: 30px;
+    margin-right: 10px;
 }
 
 .profile-info h1 {
@@ -49,13 +49,17 @@ body {
 .stat {
     text-align: center;
 }
+.stat a {
+    text-decoration: none;
+    color: inherit;
+}
 .button-container {
     text-align: right;
 }
 
 .write-post-button {
-    width: 200px;
-    padding: 10px;
+    width: 150px;
+    padding: 5px;
     background-color: #FF8E75;
     color: white;
     border: none;
@@ -107,4 +111,35 @@ body {
     cursor: pointer;
     font-weight: bold;
     font-size: 11px;
+}
+.pinIcon{
+    display: flex;
+    justify-content: end;
+}
+.icon-button {
+    display: flex;
+    justify-items: center;
+    background: #FFD6B0; /* 배경 제거 */
+    border: none; /* 테두리 제거 */
+    padding: 0; /* 패딩 제거 */
+    font-size: 20px; /* 아이콘 크기 조절 */
+    color: #FF6746; /* 아이콘 색상 설정 (필요에 따라 변경) */
+    cursor: pointer; /* 클릭 가능하게 설정 */
+}
+
+.icon-button:focus {
+    outline: none; /* 포커스 시 외곽선 제거 */
+}
+.icon-button2{
+    display: flex;
+    justify-items: center;
+    background: #FFD6B0; /* 배경 제거 */
+    border: none; /* 테두리 제거 */
+    padding: 0; /* 패딩 제거 */
+    font-size: 20px; /* 아이콘 크기 조절 */
+    color: #f90707; /* 아이콘 색상 설정 (필요에 따라 변경) */
+    cursor: pointer; /* 클릭 가능하게 설정 */
+}
+.icon-button2:focus {
+    outline: none; /* 포커스 시 외곽선 제거 */
 }

--- a/src/main/resources/static/css/feed/questionPage.css
+++ b/src/main/resources/static/css/feed/questionPage.css
@@ -189,16 +189,17 @@ body {
 .cancel-button:hover {
     background-color: #FF8E75;
 }
-.rejectedBtn, .archieveBtn {
+.rejectedBtn, .archieveBtn, .deleteBtn {
     display: flex;
     justify-content: end;
     align-items: end;
     background: none;
-    border: none;
     cursor: pointer;
     font-size: 12px;
     color: #f9916e;
     margin-right: 10px;
+    border: 1px solid #f9916e;
+    border-radius: 20px;
 }
 .likeBtn{
     margin-top: 20px;
@@ -218,4 +219,39 @@ body {
     margin-left: 5px;
     font-size: 16px;
     color: #FF6347; /* Text color */
+}
+.pinIcon{
+    display: flex;
+    justify-content: end;
+}
+.icon-button {
+    display: flex;
+    justify-items: center;
+    background: #f1f1f1; /* 배경 제거 */
+    margin-right: 15px;
+    margin-top: 10px;
+    border: none; /* 테두리 제거 */
+    padding: 0; /* 패딩 제거 */
+    font-size: 20px; /* 아이콘 크기 조절 */
+    color: #FF6746; /* 아이콘 색상 설정 (필요에 따라 변경) */
+    cursor: pointer; /* 클릭 가능하게 설정 */
+}
+
+.icon-button:focus {
+    outline: none; /* 포커스 시 외곽선 제거 */
+}
+.icon-button2{
+    display: flex;
+    justify-items: center;
+    background: #f1f1f1; /* 배경 제거 */
+    margin-right: 15px;
+    margin-top: 10px;
+    border: none; /* 테두리 제거 */
+    padding: 0; /* 패딩 제거 */
+    font-size: 20px; /* 아이콘 크기 조절 */
+    color: #f60303; /* 아이콘 색상 설정 (필요에 따라 변경) */
+    cursor: pointer; /* 클릭 가능하게 설정 */
+}
+.icon-button2:focus {
+    outline: none; /* 포커스 시 외곽선 제거 */
 }

--- a/src/main/resources/static/js/feed/commentEdit.js
+++ b/src/main/resources/static/js/feed/commentEdit.js
@@ -1,33 +1,75 @@
 document.addEventListener('DOMContentLoaded', function () {
-    // Edit button click handler
+    // 답글 작성 폼 표시 및 숨기기
+    $('.reply-comment-btn').click(function() {
+        var commentId = $(this).data('comment-id');
+        $('#replyCommentForm-' + commentId).show();
+    });
+
+    $('.cancel-reply-btn').click(function() {
+        var commentId = $(this).data('comment-id');
+        $('#replyCommentForm-' + commentId).hide();
+    });
+
+    $('.submit-reply-btn').click(function(event) {
+        event.preventDefault();
+        var commentId = $(this).data('comment-id');
+        var replyContent = $('#replyCommentContent-' + commentId).val();
+        var postId = $('input[name="postId"]').val();
+        var userId = $('input[name="userId"]').val();
+
+        $.ajax({
+            type: 'POST',
+            url: '/posts/comments/pre/' + postId,
+            data: {
+                postCommentContent: replyContent,
+                postId: postId,
+                userId: userId,
+                parentCommentPreCommentId: commentId
+            },
+            success: function(response) {
+                location.reload();
+            },
+            error: function(error) {
+                console.log('Error:', error);
+            }
+        });
+    });
+
+    // Edit button click handler for both comments and replies
     document.querySelectorAll('.edit-comment-btn').forEach(function (button) {
         button.addEventListener('click', function () {
             const commentId = button.getAttribute('data-comment-id');
-            const editForm = document.getElementById(`editCommentForm-${commentId}`);
+            const editFormComment = document.getElementById(`editCommentForm-${commentId}`);
+            const editFormReply = document.getElementById(`editReplyForm-${commentId}`);
 
-            if (editForm) {
-                editForm.style.display = 'block';
+            if (editFormComment) {
+                editFormComment.style.display = 'block';
+            } else if (editFormReply) {
+                editFormReply.style.display = 'block';
             } else {
                 console.error(`Edit form not found for comment ID: ${commentId}`);
             }
         });
     });
 
-    // Cancel button click handler
-    document.querySelectorAll('.cancel-edit-btn').forEach(function (button) {
+    // Cancel button click handler for both comments and replies
+    document.querySelectorAll('.cancel-edit-btn, .cancel-reply-edit-btn').forEach(function (button) {
         button.addEventListener('click', function () {
             const commentId = button.getAttribute('data-comment-id');
-            const editForm = document.getElementById(`editCommentForm-${commentId}`);
+            const editFormComment = document.getElementById(`editCommentForm-${commentId}`);
+            const editFormReply = document.getElementById(`editReplyForm-${commentId}`);
 
-            if (editForm) {
-                editForm.style.display = 'none';
+            if (editFormComment) {
+                editFormComment.style.display = 'none';
+            } else if (editFormReply) {
+                editFormReply.style.display = 'none';
             } else {
                 console.error(`Edit form not found for comment ID: ${commentId}`);
             }
         });
     });
 
-    // Save button click handler
+    // Save button click handler for both comments and replies
     document.querySelectorAll('.save-comment-btn').forEach(function (button) {
         button.addEventListener('click', function () {
             const commentId = button.getAttribute('data-comment-id');
@@ -48,16 +90,20 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             });
 
-            const editForm = document.getElementById(`editCommentForm-${commentId}`);
-            if (editForm) {
-                editForm.style.display = 'none';
+            const editFormComment = document.getElementById(`editCommentForm-${commentId}`);
+            const editFormReply = document.getElementById(`editReplyForm-${commentId}`);
+
+            if (editFormComment) {
+                editFormComment.style.display = 'none';
+            } else if (editFormReply) {
+                editFormReply.style.display = 'none';
             } else {
                 console.error(`Edit form not found for comment ID: ${commentId}`);
             }
         });
     });
 
-    // Delete button click handler
+    // Delete button click handler for both comments and replies
     document.querySelectorAll('.delete-comment-btn').forEach(function (button) {
         button.addEventListener('click', function () {
             const commentId = button.getAttribute('data-comment-id');

--- a/src/main/resources/static/js/feed/questionCommentEdit.js
+++ b/src/main/resources/static/js/feed/questionCommentEdit.js
@@ -2,13 +2,19 @@ $(document).ready(function() {
 
     // 답변 수정 버튼 클릭
     $(document).on('click', '.edit-button', function() {
-        $('.answer-text').hide();
-        $('.edit-button').hide();
-        $('#editForm').show();
+        // 현재 클릭된 버튼과 연관된 폼만 처리
+        const form = $(this).closest('.form-group').next('.editForm');
+
+        // 기존 답변 텍스트와 수정 버튼 숨기기
+        $(this).closest('.form-group').prev('.answer-text').hide();
+        $(this).hide();
+
+        // 수정 폼 보여주기
+        form.show();
     });
 
     // 수정된 답변 저장
-    $('#editForm').on('submit', function(event) {
+    $(document).on('submit', '.editForm', function(event) {
         event.preventDefault();
 
         const form = $(this);
@@ -20,7 +26,7 @@ $(document).ready(function() {
             url: url,
             data: { answer: editedAnswer },
             success: function(response) {
-                $('#editForm').hide();
+                form.hide();
                 window.location.reload();
             },
             error: function() {
@@ -31,8 +37,9 @@ $(document).ready(function() {
 
     // 취소 버튼 클릭
     $(document).on('click', '.cancel-button', function() {
-        $('#editForm').hide();
-        $('.answer-text').show();
-        $('.edit-button').show();
+        const form = $(this).closest('.editForm');
+        form.hide();
+        form.prev('.form-group').find('.edit-button').show();
+        form.prev('.form-group').prev('.answer-text').show();
     });
 });

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -40,7 +40,7 @@
             <!--            <button class="download-button">Download</button>-->
 
 
-            <input type="text" placeholder="질문에 대해 검색해주세요...">
+            <input type="text" placeholder="검색어를 입력해주세요...">
         </div>
     </header>
     <!-- javascript -->

--- a/src/main/resources/templates/pages/common/main.html
+++ b/src/main/resources/templates/pages/common/main.html
@@ -5,22 +5,29 @@
       layout:decorate="~{layouts/layout}">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Main</title>
     <link rel="stylesheet" th:href="@{/css/common/main.css}">
 </head>
 <body>
 <div layout:fragment="content">
     <h1>메인페이지</h1>
-    <!-- 자기가 팔로우 한 사람들의 게시글과 질문이 떠야 됨 -->
     <!-- 해당 유저의 피드로 가서 질문 창으로 갈 수 있게끔 -->
     <div class="feed-item" th:each="post : ${posts}">
         <h2 th:text="${post.postTitle}"></h2>
         <p th:text="${post.postContent}"></p>
-        <p th:text="${post.postCreatedAt}"></p>
+        <p th:text="${#temporals.format(post.postCreatedAt,'yyyy년 MM월 dd일')}"></p>
         <p>
-            <a th:href="@{/posts/{userId}(userId=${post.getUser().userId})}" th:text="${post.getUser().username}"></a>
+            <a th:href="@{/posts/{username}(username=${post.getUser().username})}" th:text="${post.getUser().username}"></a>
         </p>
-        <a th:href="@{'/posts/detail/' + ${post.postId}}"><button> 상세 보기</button></a>
+        <div class="btnContainer">
+            <button class="detailBtn"><a th:href="@{'/posts/detail/' + ${post.postId}}"> 상세 보기</a></button>
+        </div>
+    </div>
+    <div class="feed-item" th:each="question: ${questions}">
+        <h2 th:if="${question.getQuestioner()} != null" th:text="${question.getQuestioner().getUsername()}"></h2>
+        <h2 th:if="${question.getQuestioner()} == null" th:text="익명"></h2>
+        <p th:text=" ${question.getQuestion()}"></p>
+        <p th:text="${#temporals.format(question.getQuestionDate(),'yyyy년 MM월 dd일')}"></p>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/pages/feed/archievePage.html
+++ b/src/main/resources/templates/pages/feed/archievePage.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout}">
+<head>
+  <meta charset="UTF-8">
+  <title>Box</title>
+  <link rel="stylesheet" th:href="@{/css/common/main.css}">
+</head>
+<body>
+  <div layout:fragment="content">
+    <h1>보관 페이지</h1>
+    <!-- 자기가 팔로우 한 사람들의 게시글과 질문이 떠야 됨 -->
+    <!-- 해당 유저의 피드로 가서 질문 창으로 갈 수 있게끔 -->
+    <h3>피드</h3>
+    <div th:if="${posts.size() == 0}">
+      <p>보관된 피드가 없습니다.</p>
+    </div>
+    <div th:if="${posts.size() > 0}" class="feed-item" th:each="post : ${posts}">
+      <h2 th:text="${post.getPost().postTitle}"></h2>
+      <p th:text="${post.getPost().postContent}"></p>
+      <p th:text="${post.getPost().postCreatedAt}"></p>
+      <p>
+        <a th:href="@{/posts/{username}(username=${post.getPost().getUser().username})}" th:text="${post.getPost().getUser().username}"></a>
+      </p>
+      <a th:href="@{'/posts/detail/' + ${post.getPost().postId}}"><button> 상세 보기</button></a>
+    </div>
+    <h3>질문</h3>
+    <div th:if="${questions.size() == 0}">
+      <p>보관된 질문이 없습니다.</p>
+    </div>
+    <div th:if="${questions.size() > 0}" class="feed-item" th:each="question : ${questions}">
+      <a th:if="${question.getQuestion().getQuestioner()} != null">
+        <p th:text="${question.getQuestion().getQuestioner().getUsername()}"></p>
+      </a>
+      <a th:if="${question.getQuestion().getQuestioner()}== null">
+        <p th:text="익명"></p>
+      </a>
+      <h2 th:text="${question.getQuestion().getQuestion()}"></h2>
+      <p th:text="${question.getQuestion().getQuestionDate()}"></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/pages/feed/detailFeed.html
+++ b/src/main/resources/templates/pages/feed/detailFeed.html
@@ -12,13 +12,13 @@
     <script src="http://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="/js/feed/postEdit.js"></script>
     <script src="/js/feed/commentEdit.js"></script>
-    <script src="/js/feed/postLike.js"></script>
+
 </head>
 <body>
 <div layout:fragment="content">
     <div class="post-container">
         <div class="post-header">
-            <img src="프로필.png" alt="프로필 아이콘" class="profile-icon">
+            <img class="profile-icon" th:src="'/display?filename='+${post.getUser().getUserImage()}" alt="Profile Picture" />
             <div class="post-info">
                 <span class="username" th:text="${post.getUser().username}">username</span>
                 <span class="timestamp" th:text="${#temporals.format(post.getPostCreatedAt(), 'yyyy년 MM월 dd일')}">작성일</span>
@@ -76,26 +76,49 @@
             </form>
         </div>
         <div class="comments-section">
-            <div th:each="comment : ${post.postComments}" class="list-group-item">
-                <h1 class="comment-text" th:text="${comment.getUser().getUsername()}"></h1>
-                <p class="comment-text" th:text="${comment.getPostCommentContent()}"></p>
-                <input type="hidden" id="commentId" th:value="${comment.getPostCommentId()}">
-                <button class="edit-comment-btn" th:data-comment-id="${comment.getPostCommentId()}">수정</button>
-                <button class="delete-comment-btn" th:data-comment-id="${comment.getPostCommentId()}">삭제</button>
-                <div th:id="'editCommentForm-' + ${comment.getPostCommentId()}" class="edit-comment-form" style="display:none;">
-                    <textarea th:id="'editCommentContent-' + ${comment.getPostCommentId()}"></textarea>
-                    <input type="hidden" th:id="'commentId-' + ${comment.getPostCommentId()}" th:value="${comment.getPostCommentId()}" />
-                    <button class="save-comment-btn" th:data-comment-id="${comment.getPostCommentId()}">저장</button>
-                    <button class="cancel-edit-btn" th:data-comment-id="${comment.getPostCommentId()}">취소</button>
+            <div th:each="comment : ${post.postComments}">
+                <div th:if="${comment.postCommentPreCommentId == null}" class="list-group-item">
+                    <h1 class="comment-text" th:text="${comment.getUser().getUsername()}"></h1>
+                    <p class="comment-text" th:text="${comment.getPostCommentContent()}"></p>
+                    <input type="hidden" id="commentId" th:value="${comment.getPostCommentId()}">
+                    <button class="edit-comment-btn" th:data-comment-id="${comment.getPostCommentId()}">수정</button>
+                    <button class="delete-comment-btn" th:data-comment-id="${comment.getPostCommentId()}">삭제</button>
+                    <button class="reply-comment-btn" th:data-comment-id="${comment.getPostCommentId()}">답글</button>
+                    <div th:id="'editCommentForm-' + ${comment.getPostCommentId()}" class="edit-comment-form" style="display:none;">
+                        <textarea th:id="'editCommentContent-' + ${comment.getPostCommentId()}"></textarea>
+                        <input type="hidden" th:id="'commentId-' + ${comment.getPostCommentId()}" th:value="${comment.getPostCommentId()}" />
+                        <button class="save-comment-btn" th:data-comment-id="${comment.getPostCommentId()}">저장</button>
+                        <button class="cancel-edit-btn" th:data-comment-id="${comment.getPostCommentId()}">취소</button>
+                    </div>
+                    <div th:id="'replyCommentForm-' + ${comment.getPostCommentId()}" class="reply-comment-form" style="display:none;">
+                        <textarea th:id="'replyCommentContent-' + ${comment.getPostCommentId()}"></textarea>
+                        <input type="hidden" name="postId" th:value="${post.getPostId()}" />
+                        <input type="hidden" name="userId" th:value="${loginUser.getUserId()}" />
+                        <input type="hidden" th:value="${comment.getPostCommentId()}" />
+                        <button class="submit-reply-btn" th:data-comment-id="${comment.getPostCommentId()}">답글 작성</button>
+                        <button class="cancel-reply-btn" th:data-comment-id="${comment.getPostCommentId()}">취소</button>
+                    </div>
+
+                    <div th:each="reply : ${post.postComments}"
+                         th:if="${reply.postCommentPreCommentId == comment.postCommentId}"
+                         class="reply-item">
+                        <h1 class="comment-text" th:text="${reply.getUser().getUsername()}"></h1>
+                        <p class="comment-text" th:text="${reply.getPostCommentContent()}"></p>
+                        <input type="hidden" id="replyId" th:value="${reply.getPostCommentId()}">
+                        <button class="edit-comment-btn" th:data-comment-id="${reply.getPostCommentId()}">수정</button>
+                        <button class="delete-comment-btn" th:data-comment-id="${reply.getPostCommentId()}">삭제</button>
+                        <div th:id="'editReplyForm-' + ${reply.getPostCommentId()}" class="edit-reply-form" style="display:none;">
+                            <textarea th:id="'editCommentContent-' + ${reply.getPostCommentId()}"></textarea>
+                            <input type="hidden" th:id="'commentId-' + ${reply.getPostCommentId()}" th:value="${reply.getPostCommentId()}" />
+                            <button class="save-comment-btn" th:data-comment-id="${reply.getPostCommentId()}">저장</button>
+                            <button class="cancel-reply-edit-btn" th:data-comment-id="${reply.getPostCommentId()}">취소</button>
+                        </div>
+                    </div>
+
                 </div>
             </div>
         </div>
-
     </div>
 </div>
 </body>
 </html>
-
-<!--현재 User 가 not null 제약조건으로 user가 없는데 그렇게 되면 댓글 저장이 안 됨-->
-<!--그래서 내가 그냥 post_comment 의 user_id 를 null로 제약 조건 바꿔줌-->
-<!--임의로 바꾼거라 다시 not null 로 user 로그인 성공시 바꿔줘야 됨-->

--- a/src/main/resources/templates/pages/feed/filterQuestionPage.html
+++ b/src/main/resources/templates/pages/feed/filterQuestionPage.html
@@ -17,6 +17,22 @@
         <span class="user-icon">Q</span>
         <span th:text="${q.getQuestioner() != null} ? ${q.getQuestioner().username} : '익명'"></span>
       </div>
+      <div class="form-group">
+        <div th:if="${user.getUserId()} == ${loginUser.getUserId()}">
+          <form action="/questions/enroll/rejected" method="post">
+            <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+            <button type="submit" class="rejectedBtn">질문 거절</button>
+          </form>
+        </div>
+        <!--        의문스러운 점: p 태그로 할 땐 적용 안된게 div 로 하니까 됨-->
+        <div>
+          <form action="/questions/archieve" method="post">
+            <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+            <input type="hidden" name="userId" th:value="${loginUser.getUserId()}">
+            <button type="submit" class="archieveBtn">질문 보관</button>
+          </form>
+        </div>
+      </div>
       <p class="question-text" th:text="${q.getQuestion()}">질문</p>
       <img th:if="${q.getQuestionImageUrl() != null}" th:src="'/display?filename='+${q.getQuestionImageUrl()}" alt="questionImgUrl"  class="question-image" width="300px">
       <div class="form-group" th:if="${user.getUserId() != loginUser.getUserId()}">

--- a/src/main/resources/templates/pages/feed/questionPage.html
+++ b/src/main/resources/templates/pages/feed/questionPage.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="/css/feed/questionPage.css">
   <script src="http://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="/js/feed/questionCommentEdit.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.4/font/bootstrap-icons.css">
 </head>
 <body>
 <div layout:fragment="content">
@@ -38,24 +39,38 @@
       </div>
   </a>
   <div class="answered-section">
-    <p class="answered-title" th:text="${user.username} + '님에게 온 질문들'"></p>
-    <div class="answered-question" th:each="q : ${question}">
+    <h1 class="answered-title" th:text="${user.username} + '님에게 온 질문들'"></h1>
+    <h2 th:if="${pinQuestion.size()}>0"> 고정된 질문 </h2>
+    <div class="answered-question" th:each="q : ${pinQuestion}">
+      <div class="pinIcon">
+        <form th:if="${loginUser.getUserId()} == ${user.userId}" th:action="'/questions/pin/'+${q.getQuestionId()}" method="post">
+          <button type="submit" class="icon-button2">
+            <i class="bi bi-pin-fill"></i>
+          </button>
+        </form>
+        <button th:if="${loginUser.userId} != ${user.userId}" type="submit" class="icon-button">
+          <i class="bi bi-pin-fill"></i>
+        </button>
+      </div>
       <div class="answered-header">
         <span class="user-icon">Q</span>
         <span th:text="${q.getQuestioner() != null} ? ${q.getQuestioner().username} : '익명'"></span>
       </div>
       <div class="form-group">
-        <p th:if="${user.getUserId() == loginUser.getUserId()}">
+        <div th:if="${user.getUserId()} == ${loginUser.getUserId()}">
           <form action="/questions/enroll/rejected" method="post">
-              <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
-              <button type="submit" class="rejectedBtn">질문 거절</button>
+            <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+            <button type="submit" class="rejectedBtn">질문 거절</button>
           </form>
-        </p>
-        <form action="/questions/archieve" method="post">
-          <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
-          <input type="hidden" name="userId" th:value="${loginUser.getUserId()}">
-          <button type="submit" class="archieveBtn">질문 보관</button>
-        </form>
+        </div>
+        <!--        의문스러운 점: p 태그로 할 땐 적용 안된게 div 로 하니까 됨-->
+        <div>
+          <form action="/questions/archieve" method="post">
+            <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+            <input type="hidden" name="userId" th:value="${loginUser.getUserId()}">
+            <button type="submit" class="archieveBtn">질문 보관</button>
+          </form>
+        </div>
       </div>
       <p class="question-text" th:text="${q.getQuestion()}">질문</p>
       <img th:if="${q.getQuestionImageUrl() != null}" th:src="'/display?filename='+${q.getQuestionImageUrl()}" alt="questionImgUrl"  class="question-image" width="300px">
@@ -92,7 +107,7 @@
           <button class="edit-button">답변 수정</button>
         </div>
         <!--                답변 수정-->
-        <form id="editForm" style="display:none;" th:action="@{/questions/answer/edit/{questionId}(questionId=${q.getQuestionId()})}" method="post">
+        <form class="editForm" style="display:none;" th:action="@{/questions/answer/edit/{questionId}(questionId=${q.getQuestionId()})}" method="post">
           <input type="text" name="editedAnswer" class="answer-input" th:value="${q.getAnswer()}">
           <div class="form-group">
             <button type="submit" class="save-button">저장</button>
@@ -101,6 +116,84 @@
         </form>
       </a>
     </div>
+
+    <h2 th:if="${question.size()}>0"> 질문 </h2>
+      <div class="answered-question" th:each="q : ${question}">
+        <div class="pinIcon">
+          <form th:if="${loginUser.getUserId()} == ${user.userId}" th:action="'/questions/pin/'+${q.getQuestionId()}" method="post">
+            <button type="submit" class="icon-button">
+              <i class="bi bi-pin-fill"></i>
+            </button>
+          </form>
+          <button th:if="${loginUser.userId} != ${user.userId}" type="submit" class="icon-button">
+            <i class="bi bi-pin-fill"></i>
+          </button>
+        </div>
+        <div class="answered-header">
+          <span class="user-icon">Q</span>
+          <span th:text="${q.getQuestioner() != null} ? ${q.getQuestioner().username} : '익명'"></span>
+        </div>
+        <div class="form-group">
+          <div th:if="${user.getUserId()} == ${loginUser.getUserId()}">
+            <form action="/questions/enroll/rejected" method="post">
+                <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+                <button type="submit" class="rejectedBtn">질문 거절</button>
+            </form>
+          </div>
+  <!--        의문스러운 점: p 태그로 할 땐 적용 안된게 div 로 하니까 됨-->
+          <div>
+            <form action="/questions/archieve" method="post">
+              <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+              <input type="hidden" name="userId" th:value="${loginUser.getUserId()}">
+              <button type="submit" class="archieveBtn">질문 보관</button>
+            </form>
+          </div>
+        </div>
+        <p class="question-text" th:text="${q.getQuestion()}">질문</p>
+        <img th:if="${q.getQuestionImageUrl() != null}" th:src="'/display?filename='+${q.getQuestionImageUrl()}" alt="questionImgUrl"  class="question-image" width="300px">
+        <div class="form-group" th:if="${user.getUserId()} != ${loginUser.getUserId()}">
+          <form th:action="@{/questions/like}" method="post" class="likeForm">
+            <input type="hidden" name="userId" th:value="${loginUser.getUserId()}">
+            <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+            <button type="submit" class="likeBtn">
+              ❤<span class="likeCount" th:text="${q.getQuestionLike()}"></span>
+            </button>
+          </form>
+        </div>
+        <div class="form-group" th:if="${user.getUserId()} == ${loginUser.getUserId()}">
+          <button type="submit" class="likeBtn" disabled>
+            ❤<span class="likeCount" th:text="${q.getQuestionLike()}"></span>
+          </button>
+        </div>
+        <p class="question-date" th:text="'질문 작성 날짜: '+${#temporals.format(q.getQuestionDate(), 'yyyy년 MM월 dd일')}">질문 작성 날짜</p>
+        <!--            여기 부분에서 답변하기는 유저 정보 가져왔을 때 해당 질문창의 유저만 답변 폼 볼 수 있게 처리할 것임!!!-->
+        <a th:if="${q.getAnswer() == null && user.getUserId() == loginUser.getUserId()}" >
+          <form th:action="@{/questions/answer/{questionId}(questionId=${q.getQuestionId()})}" method="post">
+            <input type="text" name="answer" class="answer-input" placeholder="답장을 입력해주세요.">
+            <div class="form-group">
+              <button type="submit" class="send-button">답변하기</button>
+            </div>
+          </form>
+        </a>
+        <a th:if="${q.getAnswer() != null} ">
+          <p class="answer-text" th:text="${q.getAnswer()}">답변</p>
+          <div class="form-group">
+            <p class="answer-date" th:text="'답장 날짜: '+${#temporals.format(q.getAnswerDate(), 'yyyy년 MM월 dd일')}">답변 작성 날짜</p>
+          </div>
+          <div class="form-group" th:if="${user.getUserId() == loginUser.getUserId()}">
+            <button class="edit-button">답변 수정</button>
+          </div>
+          <!--                답변 수정-->
+          <form class="editForm" style="display:none;" th:action="@{/questions/answer/edit/{questionId}(questionId=${q.getQuestionId()})}" method="post">
+            <input type="text" name="editedAnswer" class="answer-input" th:value="${q.getAnswer()}">
+            <div class="form-group">
+              <button type="submit" class="save-button">저장</button>
+              <button type="button" class="cancel-button">취소</button>
+            </div>
+          </form>
+        </a>
+      </div>
+    </h2>
   </div>
 </div>
 

--- a/src/main/resources/templates/pages/feed/rejectedQuestionPage.html
+++ b/src/main/resources/templates/pages/feed/rejectedQuestionPage.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>rejectedfilterQuestionPage</title>
+    <link rel="stylesheet" th:href="@{/css/feed/questionPage.css}">
+</head>
+<body>
+<div layout:fragment="content">
+    <h1>질문 목록</h1>
+    <div class="answered-section">
+        <div class="answered-question" th:each="q : ${question}">
+            <div class="answered-header">
+                <span class="user-icon">Q</span>
+                <span th:text="${q.getQuestioner() != null} ? ${q.getQuestioner().username} : '익명'"></span>
+            </div>
+            <div class="form-group">
+                <div th:if="${user.getUserId()} == ${loginUser.getUserId()}">
+                    <form action="/questions/enroll/rejected" method="post">
+                        <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+                        <button type="submit" class="rejectedBtn">거절 취소</button>
+                    </form>
+                </div>
+                <!--        의문스러운 점: p 태그로 할 땐 적용 안된게 div 로 하니까 됨-->
+                <div>
+                    <form action="/questions/archieve" method="post">
+                        <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+                        <input type="hidden" name="userId" th:value="${loginUser.getUserId()}">
+                        <button type="submit" class="archieveBtn">질문 보관</button>
+                    </form>
+                </div>
+                <div>
+                    <form action="/questions/delete" method="post">
+                        <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+                        <button type="submit" class="deleteBtn">질문 삭제</button>
+                    </form>
+                </div>
+            </div>
+            <p class="question-text" th:text="${q.getQuestion()}">질문</p>
+            <img th:if="${q.getQuestionImageUrl() != null}" th:src="'/display?filename='+${q.getQuestionImageUrl()}" alt="questionImgUrl"  class="question-image" width="300px">
+            <div class="form-group" th:if="${user.getUserId() != loginUser.getUserId()}">
+                <form th:action="@{/questions/like}" method="post">
+                    <input type="hidden" name="userId" th:value="${loginUser.getUserId()}">
+                    <input type="hidden" name="questionId" th:value="${q.getQuestionId()}">
+                    <button type="submit" class="likeBtn">
+                        ❤<span class="likeCount" th:text="${q.getQuestionLike()}"></span>
+                    </button>
+                </form>
+            </div>
+            <div class="form-group" th:if="${user.getUserId() == loginUser.getUserId()}">
+                <button type="submit" class="likeBtn">
+                    ❤<span class="likeCount" th:text="${q.getQuestionLike()}"></span>
+                </button>
+            </div>
+            <p class="question-date" th:text="'질문 작성 날짜: '+${#temporals.format(q.getQuestionDate(), 'yyyy년 MM월 dd일')}">질문 작성 날짜</p>
+            <a th:if="${q.getAnswer() != null} ">
+                <p class="answer-text" th:text="${q.getAnswer()}">답변</p>
+                <div class="form-group">
+                    <p class="answer-date" th:text="'답장 날짜: '+${#temporals.format(q.getAnswerDate(), 'yyyy년 MM월 dd일')}">답변 작성 날짜</p>
+                </div>
+            </a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/pages/feed/userFeed.html
+++ b/src/main/resources/templates/pages/feed/userFeed.html
@@ -9,20 +9,21 @@
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="/css/feed/feed.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.4/font/bootstrap-icons.css">
     <title>사용자 전체 피드 보기</title>
 </head>
 <body>
     <div layout:fragment="content">
         <div class="profile-container">
             <div class="profile-header">
-                <div class="profile-picture">
-                    <img src="텀블벅.jpg" alt="Profile Picture" />
+                <div>
+                    <img class="profile-picture" th:src="'/display?filename='+${user.getUserImage()}" alt="Profile Picture" />
                 </div>
             </div>
             <div class="profile-header">
                 <div class="profile-info">
-                    <h1 th:text="${user.username}">Username</h1>
-                    <p>팔로워 100 | 팔로잉 2</p>
+                    <h1 th:text="${user.getUsername()}"></h1>
+                    <p th:text="'팔로워 '+${followers}+' | 팔로잉 '+${followings}"></p>
                 </div>
             </div>
             <div class="profile-stats">
@@ -45,14 +46,50 @@
             </div>
             <div class="button-container">
                 <a th:if="${user.userId} != ${loginUser.userId}" th:href="@{'/questions/create/'+${user.userId}}"><button class="write-post-button">질문 작성</button></a>
+                <a th:if="${user.userId} == ${loginUser.userId}" th:href="@{'/all/archieve/'+${user.userId}}"><button class="write-post-button">보관함</button></a>
                 <a th:if="${user.userId} == ${loginUser.userId}" th:href="@{/posts/create}"><button class="write-post-button">피드 작성</button></a>
             </div>
             <div class="feed">
+                <h2 th:if="${pinPosts.size()}>0">고정된 피드</h2>
+                <div class="feed-item" th:each="p : ${pinPosts}">
+                    <div class="post">
+                        <div class="pinIcon">
+                            <form th:if="${loginUser.getUserId()} == ${user.userId}" th:action="'/posts/pin/'+${p.postId}" method="post">
+                                <button type="submit" class="icon-button2">
+                                    <i class="bi bi-pin-fill"></i>
+                                </button>
+                            </form>
+                            <button th:if="${loginUser.userId} != ${user.userId}" type="submit" class="icon-button">
+                                <i class="bi bi-pin-fill"></i>
+                            </button>
+                        </div>
+                        <h2 th:text="${p.getPostTitle()}"></h2>
+                        <p th:text="${p.getPostContent()}"></p>
+                        <img th:src="'/display?filename='+${p.getPostImageUrl()}" alt="Post Image">
+                        <a th:text="${#temporals.format(p.getPostCreatedAt(), 'yyyy년 MM월 dd일')}"></a>
+                        <div class="feed-actions">
+                            <a th:href="@{'/posts/detail/' + ${p.postId}}"><button>피드 상세 보기</button></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="feed">
+                <h2 th:if="${posts.size()} > 0">피드</h2>
                 <div class="feed-item" th:each="post : ${posts}">
                     <div class="post">
+                        <div class="pinIcon">
+                            <form th:if="${loginUser.getUserId()} == ${user.userId}" th:action="'/posts/pin/'+${post.postId}" method="post">
+                                <button type="submit" class="icon-button">
+                                    <i class="bi bi-pin-fill"></i>
+                                </button>
+                            </form>
+                            <button th:if="${loginUser.userId} != ${user.userId}" type="submit" class="icon-button">
+                                <i class="bi bi-pin-fill"></i>
+                            </button>
+                        </div>
                         <h2 th:text="${post.getPostTitle()}"></h2>
                         <p th:text="${post.getPostContent()}"></p>
-                        <img th:src="'/display?filename='+${post.getPostImageUrl()}" alt="Post Image">
+                        <img th:if="${post.getPostImageUrl() != null}" th:src="'/display?filename='+${post.getPostImageUrl()}" alt="Post Image">
                         <a th:text="${#temporals.format(post.getPostCreatedAt(), 'yyyy년 MM월 dd일')}"></a>
                         <div class="feed-actions">
                             <a th:href="@{'/posts/detail/' + ${post.postId}}"><button>피드 상세 보기</button></a>

--- a/src/main/resources/templates/pages/user/profileSetting.html
+++ b/src/main/resources/templates/pages/user/profileSetting.html
@@ -32,7 +32,7 @@
             <div class="form-row">
                 <label for="profile-url">내 프로필 주소</label>
                 <div class="input-group">
-                    <input type="text" id="profile-url" placeholder="내 프로 주소" th:value="'http://localhost:8080/post/'+${profile.username}" readonly>
+                    <input type="text" id="profile-url" placeholder="내 프로 주소" th:value="'http://localhost:8080/posts/'+${profile.username}" readonly>
                     <button class="btn-copy" id="copyProfileUrl">복사</button>
                 </div>
             </div>


### PR DESCRIPTION
좋아요 전체 관리 (post 와 question 좋아요 테이블 합쳐서 관리)
DB 수정
```sql
CREATE TABLE `likes` (
    `likes_id` BIGINT NOT NULL AUTO_INCREMENT,
    `question_id` BIGINT NULL,
    `user_id` BIGINT NULL,
    `post_id` BIGINT NULL,
    PRIMARY KEY (`likes_id`),
    FOREIGN KEY (`post_id`) REFERENCES `posts` (`post_id`) ON DELETE CASCADE,
    FOREIGN KEY (`question_id`) REFERENCES `questions` (`question_id`) ON DELETE CASCADE,
    FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE
);
```

질문 테이블에는 
question_like  컬럼이 없어서
```sql
ALTER TABLE questions
    ADD COLUMN question_like INT NULL DEFAULT 0;
```
추가했다.

<mark>노션 전체 코드에 반영 완료!</mark>

- post 
좋아요 갯수 (좋아요)

- question
새 질문 목록( 답장 안 된 걸 기준) 
거절 질문 등록(거절 질문 버튼 누를 시) -> 거절 질문 보관함으로! 
질문 거절을 할 시, 굳이 답변 삭제를 할 필요가 없으니 안 만들어도 될 거 같다는 얘기가 나옴!
답변 질문 목록
질문의 좋아요
보낸 질문 목록(이때의 보낸 질문은 익명은 포함 X)


08/07 
- post  의 보관함

- post 댓글
댓글 user 정보 반영해서 쓰도록 수정.

발표 진행 (3~6)
<strong>코드 리펙토링 살짝 하면서 진행하기</strong>


08/08 ~ 08/09
혜빈님이랑 상의했던 부분 고민해보기 (알림+질문창+피드창)

- 호현님의 유저 설정 부분에서 posts/{username} 으로 매핑되게 코드 수정
- question 의 보관함 
- 질문 거절에 대한 필터 (loginUser == 질문 페이지 user)
- 새 질문에서 답장 안 될걸 기준으로, createAt 내림차순으로 정렬해서 보여주게 수정

- question과 feed 가 둘 다 main 에서 보일 수 있게 설정
- 고정 pin 설정 (고정된 피드, 질문 상단에 위치하게)



- 대댓글 수정 삭제
- 질문 삭제 , 차단 질문 해제, 질문 신고(버튼만)
- 질문할 때, 익명일 경우, ip 주소 저장시키는거 로직 구현 <mark> 전체 db 쿼리문에 반영 완료! </mark>
- 코드 정리 (현재 굉장히 뭔가 복잡해 보임)

### 08/12 예정 _  report 컬럼 수정해야 될거 같음!
- 신고 (신고폼)
포스트 신고 (포스트 내용, 포스트 게시자, 신고자)
질문 신고 (질문 내용, 질문 보낸 사람 (userId, userIp) , 신고자)
댓글 신고 (댓글 내용, 댓글 쓴 사람, 신고자)
### 비로그인, 로그인 따로 로직 생각해서 다시 코드 짜기
로직을 다시 생각해야 됨
비로그인도 main 으로 갈 수 있고, 피드, 질문 확인할 수 있고 (좋아요 스크랩 댓글 불가), 질문 익명으로 작성할 수 있는 권한 
로그인은 원래 로직대로가 맞음!

close #67